### PR TITLE
Add `endkey` support, and make README more consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 test.py
 
+# We use requirements.txt for this project
+Pipfile
+Pipfile.lock
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,140 @@
+test.py
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/README.md
+++ b/README.md
@@ -278,17 +278,17 @@ r = p.get_user_profile(username="")
 ## Network 
 
 If you've collected some Parler post data, you can create a network of their mentions in Gephi with: 
-
+```
 pyrler/utilities/network.py data.jsonl network_of_data.gexf
-
+```
 Create a network of their hashtags. 
-
+```
 pyrler/utilities/network.py --hashtags data.jsonl network_of_data.gexf
-
+```
 Create a network of their echos.
-
+```
 pyrler/utilities/network.py --echo data.jsonl network_of_data.gexf
-
+```
 Additionally if you want to convert the network into a dynamic network with timeline enabled (i.e. nodes will appear and disappear according to their  attributes), you can open up your GEXF file in Gephi and follow [these instructions](https://seinecle.github.io/gephi-tutorials/generated-html/converting-a-network-with-dates-into-dynamic.html). Note that in network_of_data.gexf there is a column for "start_date" (which is the day the post was created) but none for "end_date" and that in the dynamic timeline, the nodes will appear on the screen at their start date and stay on screen forever after.  For the "Time Interval creation options" pop-up in Gephi, the "Start time column" should be "start_date", the "End time column" should be empty, the "Parse dates" should be selected, and the Date format should be the last option, "dd/MM/yyyy HH:mm:ss".
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ r = p.get_followers(user_id="user_id")
 Get the accounts a user is following.
 ```
 p = pyrler.Follow()
-r = p.get_followers(user_id="user_id")
+r = p.get_following(user_id="user_id")
 ```
 
 Follow a user.

--- a/README.md
+++ b/README.md
@@ -26,28 +26,36 @@ Both stdout and file handlers can be enabled together.
 
 ### Pagination
 
-Pyrler pulls only the first page of results by default.  To use pagination pass a function the `follow` arg.
+Pyrler pulls only the first page of results by default.  To use pagination pass a truthy value to the `follow` argument.
 
 Parler pages are indexed by `startkey` and each response returns a `next` value used to access the next page.
 
 Let's look at a user's post history. First we find the user's `id` by fetching their profile. 
 ```
 profile = pyrler.Profile()
-profile_response = profile.get_user_profile(username="AltCyberCommand")
+profile_response = profile.get_user_profile(username="SeanHannity")
 user_id = profile_response.json().get("id")
 ```
 
 Now we fetch their post history starting with the first page of data.
 ```
 p = pyrler.Post()
-r = p.get_user_posts(id=user_id, startkey=None, follow=True)
+r = p.get_user_posts(user_id=user_id, startkey=None, follow=True)
 ```
+
+You can specify the `endkey` argument to stop pagination after a certain time. `endkey` must be formatted as a timestamp (as Parler returns for its `prev`/`next` keys). For example:
+
+```
+r = p.get_user_posts(user_id=user_id, startkey=None, endkey="2021-02-16T14:53:30.429Z_322497", follow=True)
+```
+
+Note that you may still receive results earlier than `endkey` if they are on a page whose last result is _after_ `endkey`. `endkey` simply prevents pagination from continuing further back in time.
 
 Wow. Much shitposting.
 
 ## Methods
 
-Take a look at `pyrler.core.pyrler.py` for the complete list of methods.
+Take a look at `pyrler/core/pyrler.py` for the complete list of methods.
 
 Methods return a dict by default and a list of dicts when `follow=True`.
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,21 @@ p = pyrler.Profile()
 r = p.get_user_profile(username="")
 ```
 
+## Network 
+
+If you've collected some Parler post data, you can create a network of their mentions in Gephi with: 
+
+pyrler/utilities/network.py data.jsonl network_of_data.gexf
+
+Create a network of their hashtags. 
+
+pyrler/utilities/network.py --hashtags data.jsonl network_of_data.gexf
+
+Create a network of their echos.
+
+pyrler/utilities/network.py --echo data.jsonl network_of_data.gexf
+
+Additionally if you want to convert the network into a dynamic network with timeline enabled (i.e. nodes will appear and disappear according to their  attributes), you can open up your GEXF file in Gephi and follow [these instructions](https://seinecle.github.io/gephi-tutorials/generated-html/converting-a-network-with-dates-into-dynamic.html). Note that in network_of_data.gexf there is a column for "start_date" (which is the day the post was created) but none for "end_date" and that in the dynamic timeline, the nodes will appear on the screen at their start date and stay on screen forever after.  For the "Time Interval creation options" pop-up in Gephi, the "Start time column" should be "start_date", the "End time column" should be empty, the "Parse dates" should be selected, and the Date format should be the last option, "dd/MM/yyyy HH:mm:ss".
 
 ## Credits
 

--- a/pyrler/core/pyrler.py
+++ b/pyrler/core/pyrler.py
@@ -862,42 +862,45 @@ class Post(_Parler):
         return self._get_request(route=route, **kwargs)
 
     @paginate
-    def get_user_posts(self, post_id=None, startkey=None, follow=None, **kwargs):
+    def get_user_posts(self, user_id=None, post_id=None, startkey=None, follow=None, **kwargs):
         """
         Returns posts created by a user.
-        :param id: User ID
+        :param user_id: User ID
         :param startkey:
         :param kwargs:
         :return:
         """
+        # We fallback to `post_id` to avoid breaking API changes
         route = "/v1/post/creator"
-        request_params = {"id": post_id, "startkey": startkey}
+        request_params = {"id": user_id or post_id, "startkey": startkey}
         return self._get_request(route=route, params=request_params, **kwargs)
 
     @paginate
-    def get_liked_posts(self, post_id=None, startkey=None, follow=None, **kwargs):
+    def get_liked_posts(self, user_id=None, post_id=None, startkey=None, follow=None, **kwargs):
         """
         Returns posts liked by a user.
-        :param post_id: post ID
+        :param user_id: user ID
         :param startkey:
         :param kwargs:
         :return:
         """
+        # We fallback to `post_id` to avoid breaking API changes
         route = "/v1/post/creator/liked"
-        request_params = {"id": post_id, "startkey": startkey}
+        request_params = {"id": user_id or post_id, "startkey": startkey}
         return self._get_request(route=route, params=request_params, **kwargs)
 
     @paginate
-    def get_creator_media(self, post_id=None, startkey=None, follow=None, **kwargs):
+    def get_creator_media(self, user_id=None, post_id=None, startkey=None, follow=None, **kwargs):
         """
         Returns media posted by a user.
-        :param post_id: User ID
+        :param user_id: User ID
         :param startkey:
         :param kwargs:
         :return:
         """
+        # We fallback to `post_id` to avoid breaking API changes
         route = "/v1/post/creator/media"
-        request_params = {"id": post_id, "startkey": startkey}
+        request_params = {"id": user_id or post_id, "startkey": startkey}
         return self._get_request(route=route, params=request_params, **kwargs)
 
     @paginate

--- a/pyrler/utilities/client.py
+++ b/pyrler/utilities/client.py
@@ -30,6 +30,7 @@ def client():
 
     adapter = TimeoutHTTPAdapter(timeout=2, max_retries=retry_strategy)
     session = requests.Session()
+    session.headers["User-Agent"] = "Parler%20Staging/545 CFNetwork/978.0.7 Darwin 18.7.0"
     session.mount("https://", adapter)
     session.mount("http://", adapter)
 

--- a/pyrler/utilities/network.py
+++ b/pyrler/utilities/network.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+
+# build a mention graph from a file of Parler posts data and write it
+# out as a gexf file
+#
+#   ./network.py parler_posts.jsonl parler_posts.gexf
+#
+# to build the hashtag colocation graph (i.e. have the graph oriented around nodes that are hashtags
+# instead of posts or users), use the --hashtags flag
+#
+#  ./network.py --hashtags parler_posts.jsonl parler_posts.gexf
+#
+# to build the echo graph, use the --echo flag
+#
+#  ./network.py --echo parler_posts.jsonl parler_posts.gexf
+#
+#
+
+import sys
+import json
+import networkx
+import optparse
+import itertools
+import time
+
+from networkx import nx_pydot
+from networkx.readwrite import json_graph
+
+usage = "network.py parler_posts.jsonl graph.gexf"
+opt_parser = optparse.OptionParser(usage=usage)
+
+opt_parser.add_option(
+    "--min_subgraph_size",
+    dest="min_subgraph_size",
+    type="int",
+    help="remove any subgraphs with a size smaller than this number"
+)
+
+opt_parser.add_option(
+    "--max_subgraph_size",
+    dest="max_subgraph_size",
+    type="int",
+    help="remove any subgraphs with a size larger than this number"
+)
+
+opt_parser.add_option(
+    "--hashtags",
+    dest="hashtags",
+    action="store_true",
+    help="show hashtag relations instead of mention relations"
+)
+
+opt_parser.add_option(
+    "--echo",
+    dest="echo",
+    action="store_true",
+    help="show echo relations instead of mention relations"
+)
+
+options, args = opt_parser.parse_args()
+
+if len(args) != 2:
+    opt_parser.error("must supply input and output file names")
+
+parler_posts, output = args
+
+G = networkx.DiGraph()
+
+
+def add(from_user, from_id, to_user, to_id, type, created_at=None):
+    # Adds a relation to the graph
+    # Note: storing start_data will allow for timestamps for gephi timeline, where nodes will appear on screen at their start dataset
+    # and stay on forever after
+
+	G.add_node(from_user, screen_name=from_user, start_date=created_at)
+	G.add_node(to_user, screen_name=to_user, start_date=created_at)
+
+	if G.has_edge(from_user, to_user):
+		weight = G[from_user][to_user]['weight'] + 1
+	else:
+		weight = 1
+	G.add_edge(from_user, to_user, type=type, weight=weight)
+
+def convert_date(unconverted_date):
+    # Converts 14 digit time to 'dd/MM/yyyy HH:mm:ss' format
+    # and returns newly formatted date
+    unconverted_date = str(unconverted_date)
+    converted_date = time.strftime('%d/%m/%Y %H:%M:%S', time.strptime(unconverted_date,'%Y%m%d%H%M%S'))
+    return converted_date
+
+for line in open(parler_posts):
+    try:
+        t = json.loads(line)
+    except:
+        continue
+    from_id = t['_id']
+    from_user = t['creator']['username']
+    from_user_id = t['creator']['id']
+    to_user = None
+    to_id = None
+    created_at_date = convert_date(t["createdAt"])
+
+    if options.hashtags: # hashtag graph
+        hashtags = t['hashtags']
+        hashtag_pairs = list(itertools.combinations(hashtags, 2)) # list of all possible hashtag pairs
+        for u in hashtag_pairs:
+            # source hashtag: u[0]
+            # target hashtag: u[1]
+            add('#' + u[0], None, '#' + u[1], None, 'hashtag', created_at_date)
+    elif options.echo: # echo graph
+        if "parent" in t:
+            # t['parent']['creator'] is ID of creator whereas t['parent']['_id'] is ID of the post
+            # t['parent'] does not include parent username
+            add(from_user, from_id, t['parent']['creator'], t['parent']['_id'], 'echo', created_at_date)
+    else: # mention graph
+        for (screen_name, user_id) in t['@'].items():
+            add(from_user, from_id, screen_name, user_id, 'mention', created_at_date)
+
+
+if options.min_subgraph_size or options.max_subgraph_size:
+    g_copy = G.copy()
+    for g in networkx.connected_component_subgraphs(G):
+        if options.min_subgraph_size and len(g) < options.min_subgraph_size:
+            g_copy.remove_nodes_from(g.nodes())
+        elif options.max_subgraph_size and len(g) > options.max_subgraph_size:
+            g_copy.remove_nodes_from(g.nodes())
+    G = g_copy
+
+networkx.write_gexf(G, output)

--- a/pyrler/utilities/wrappers.py
+++ b/pyrler/utilities/wrappers.py
@@ -15,6 +15,13 @@ def paginate(func):
             else:
                 startkey = None
 
+            # End at the user defined index otherwise go back as far as possible.
+            if kwargs.get("endkey"):
+                endkey = kwargs.get("endkey")
+                del kwargs["endkey"]
+            else:
+                endkey = None
+
             # Fetch pages until we've got them or something breaks.
             while True:
                 r = func(startkey=startkey, *args, **kwargs)
@@ -39,7 +46,12 @@ def paginate(func):
                     logger.debug("Next page could not be returned. Check requests debug log.")
                     break
 
+                if endkey is not None and r.json().get("next") < endkey:
+                    logger.debug("Next page is earlier than endkey!")
+                    break
+
                 startkey = r.json().get("next")
+            
             return data
         else:
             return func(*args, **kwargs)

--- a/tests/main.py
+++ b/tests/main.py
@@ -1,0 +1,16 @@
+import unittest
+from pyrler.core import pyrler
+
+class TestUserMethods(unittest.TestCase):
+    def test_user_posts(self):
+        profile = pyrler.Profile()
+        profile_response = profile.get_user_profile(username="SeanHannity")
+        user_id = profile_response.json().get("id")
+        p = pyrler.Post()
+        out = p.get_user_posts(post_id=user_id, follow=True, endkey="2021-02-20T14:53:30.429Z_322497")
+        all_posts = sum([k.json()["posts"] for k in out], [])
+        print(f"Found {len(all_posts)} posts from Sean Hannity")
+        self.assertGreater(len(all_posts), 10)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
There are a few changes in here that are a bit opinionated; for example, I changed the argument from `post_id` to `user_id` in functions where the arg should specify a user (but I did the change in such a way that no one's code will break).

The big change here is the addition of `endkey`, which allows pagination to stop after a certain point.

TODO:

- [ ] Add tests for more endpoints
- [ ] Add more error resiliency (it doesn't seem too bad right now; afaik, it retries on 500's, for example)